### PR TITLE
Sinusoidal no outputs

### DIFF
--- a/benchmarks/sinusoidal_large/assets/sinusoidal_no_size_args.tcl
+++ b/benchmarks/sinusoidal_large/assets/sinusoidal_no_size_args.tcl
@@ -326,24 +326,57 @@ pfset Geom.domain.ICPressure.RefPatch                   z-upper
 # Outputs
 # ------------------------------------------------------------
 #Writing output (all pfb):
+pfset Solver.PrintCLM                                 False
+pfset Solver.PrintConcentration                       False
+pfset Solver.PrintDZMultiplier                        False
+pfset Solver.PrintEvapTrans                           False
+pfset Solver.PrintEvapTransSum                        False
+pfset Solver.PrintLSMSink                             False
+pfset Solver.PrintMannings                            False
+pfset Solver.PrintMask                                False
+pfset Solver.PrintOverlandBCFlux                      False
+pfset Solver.PrintOverlandSum                         False
+pfset Solver.PrintPressure                            False
+pfset Solver.PrintSaturation                          False
+pfset Solver.PrintSlopes                              False
+pfset Solver.PrintSpecificStorage                     False
 pfset Solver.PrintSubsurfData                         False
-pfset Solver.PrintPressure                            True
-pfset Solver.PrintSaturation                          True
-pfset Solver.PrintMask                                True
+pfset Solver.PrintTop                                 False
+pfset Solver.PrintVelocities                          False
+pfset Solver.PrintWells                               False
 
 pfset Solver.WriteCLMBinary                           False
-pfset Solver.PrintCLM                                 True
-pfset Solver.WriteSiloSpecificStorage                 False
-pfset Solver.WriteSiloMannings                        False
-pfset Solver.WriteSiloMask                            False
-pfset Solver.WriteSiloSlopes                          False
-pfset Solver.WriteSiloSubsurfData                     False
-pfset Solver.WriteSiloPressure                        False
-pfset Solver.WriteSiloSaturation                      False
+pfset Solver.WriteSiloCLM                             False
+pfset Solver.WriteSiloConcentration                   False
+pfset Solver.WriteSiloDZMultiplier                    False
 pfset Solver.WriteSiloEvapTrans                       False
 pfset Solver.WriteSiloEvapTransSum                    False
+pfset Solver.WriteSiloMannings                        False
+pfset Solver.WriteSiloMask                            False
+pfset Solver.WriteSiloOverlandBCFlux                  False
 pfset Solver.WriteSiloOverlandSum                     False
-pfset Solver.WriteSiloCLM                             False
+pfset Solver.WriteSiloPMPIOConcentration              False
+pfset Solver.WriteSiloPMPIODZMultiplier               False
+pfset Solver.WriteSiloPMPIOEvapTrans                  False
+pfset Solver.WriteSiloPMPIOEvapTransSum               False
+pfset Solver.WriteSiloPMPIOMannings                   False
+pfset Solver.WriteSiloPMPIOMask                       False
+pfset Solver.WriteSiloPMPIOOverlandBCFlux             False
+pfset Solver.WriteSiloPMPIOOverlandSum                False
+pfset Solver.WriteSiloPMPIOPressure                   False
+pfset Solver.WriteSiloPMPIOSaturation                 False
+pfset Solver.WriteSiloPMPIOSlopes                     False
+pfset Solver.WriteSiloPMPIOSpecificStorage            False
+pfset Solver.WriteSiloPMPIOSubsurfData                False
+pfset Solver.WriteSiloPMPIOTop                        False
+pfset Solver.WriteSiloPMPIOVelocities                 False
+pfset Solver.WriteSiloPressure                        False
+pfset Solver.WriteSiloSaturation                      False
+pfset Solver.WriteSiloSlopes                          False
+pfset Solver.WriteSiloSpecificStorage                 False
+pfset Solver.WriteSiloSubsurfData                     False
+pfset Solver.WriteSiloTop                             False
+pfset Solver.WriteSiloVelocities                      False
 
 #-----------------------------------------------------------------------------
 # Exact solution specification for error calculations

--- a/benchmarks/sinusoidal_large/assets/validate_results.tcl
+++ b/benchmarks/sinusoidal_large/assets/validate_results.tcl
@@ -10,46 +10,8 @@ set py_test_epsilon 9
 
 set passed 1
 
-
-# if ![pftestFile $runname.out.press.00000.pfb "Max difference in Pressure" $sig_digits] {
-#     set passed 0
-# }
-
-# set status [catch { exec python ../pfbdiff.py -q -e=1e-$py_test_epsilon $runname.out.press.00000.pfb ./correct_output/$runname.out.press.00000.pfb } result]
-# if { $status != 0 } {
-#   set passed 0
-#   puts $result
-# }
-
-# if ![pftestFile $runname.out.satur.00000.pfb "Max difference in Saturation" $sig_digits] {
-#     set passed 0
-# }
-
-# set status [catch { exec python ../pfbdiff.py -q -e=1e-$py_test_epsilon ./$runname.out.satur.00000.pfb ./correct_output/$runname.out.satur.00000.pfb } result]
-# if { $status != 0 } {
-#   set passed 0
-#   puts $result
-# }
-
-# foreach file "LW.out.eflx_lh_tot.00012.pfb
-#     LW.out.qflx_evap_soi.00012.pfb LW.out.swe_out.00012.pfb
-#     LW.out.eflx_lwrad_out.00012.pfb LW.out.qflx_evap_tot.00012.pfb
-#     LW.out.t_grnd.00012.pfb LW.out.eflx_sh_tot.00012.pfb
-#     LW.out.qflx_evap_veg.00012.pfb LW.out.t_soil.00012.pfb
-#     LW.out.eflx_soil_grnd.00012.pfb LW.out.qflx_infl.00012.pfb
-#     LW.out.qflx_evap_grnd.00012.pfb LW.out.qflx_tran_veg.00012.pfb" {
-
-#     if ![pftestFile $file "Max difference in $file" $sig_digits] { 
-#     set passed 0
-#     }
-    
-#     set status [catch { exec python ../pfbdiff.py -q -e=1e-$py_test_epsilon $file correct_output/$file  } result]
-#     if { $status != 0 } {
-#       set passed 0
-#       puts $result
-#     }
-    
-# }
+# TODO add validation.
+# PS: When adding validation, make sure to turn on outputs in the run script
 
 if $passed {
     puts "$runname : PASSED"

--- a/benchmarks/sinusoidal_medium/assets/sinusoidal_no_size_args.tcl
+++ b/benchmarks/sinusoidal_medium/assets/sinusoidal_no_size_args.tcl
@@ -326,24 +326,57 @@ pfset Geom.domain.ICPressure.RefPatch                   z-upper
 # Outputs
 # ------------------------------------------------------------
 #Writing output (all pfb):
+pfset Solver.PrintCLM                                 False
+pfset Solver.PrintConcentration                       False
+pfset Solver.PrintDZMultiplier                        False
+pfset Solver.PrintEvapTrans                           False
+pfset Solver.PrintEvapTransSum                        False
+pfset Solver.PrintLSMSink                             False
+pfset Solver.PrintMannings                            False
+pfset Solver.PrintMask                                False
+pfset Solver.PrintOverlandBCFlux                      False
+pfset Solver.PrintOverlandSum                         False
+pfset Solver.PrintPressure                            False
+pfset Solver.PrintSaturation                          False
+pfset Solver.PrintSlopes                              False
+pfset Solver.PrintSpecificStorage                     False
 pfset Solver.PrintSubsurfData                         False
-pfset Solver.PrintPressure                            True
-pfset Solver.PrintSaturation                          True
-pfset Solver.PrintMask                                True
+pfset Solver.PrintTop                                 False
+pfset Solver.PrintVelocities                          False
+pfset Solver.PrintWells                               False
 
 pfset Solver.WriteCLMBinary                           False
-pfset Solver.PrintCLM                                 True
-pfset Solver.WriteSiloSpecificStorage                 False
-pfset Solver.WriteSiloMannings                        False
-pfset Solver.WriteSiloMask                            False
-pfset Solver.WriteSiloSlopes                          False
-pfset Solver.WriteSiloSubsurfData                     False
-pfset Solver.WriteSiloPressure                        False
-pfset Solver.WriteSiloSaturation                      False
+pfset Solver.WriteSiloCLM                             False
+pfset Solver.WriteSiloConcentration                   False
+pfset Solver.WriteSiloDZMultiplier                    False
 pfset Solver.WriteSiloEvapTrans                       False
 pfset Solver.WriteSiloEvapTransSum                    False
+pfset Solver.WriteSiloMannings                        False
+pfset Solver.WriteSiloMask                            False
+pfset Solver.WriteSiloOverlandBCFlux                  False
 pfset Solver.WriteSiloOverlandSum                     False
-pfset Solver.WriteSiloCLM                             False
+pfset Solver.WriteSiloPMPIOConcentration              False
+pfset Solver.WriteSiloPMPIODZMultiplier               False
+pfset Solver.WriteSiloPMPIOEvapTrans                  False
+pfset Solver.WriteSiloPMPIOEvapTransSum               False
+pfset Solver.WriteSiloPMPIOMannings                   False
+pfset Solver.WriteSiloPMPIOMask                       False
+pfset Solver.WriteSiloPMPIOOverlandBCFlux             False
+pfset Solver.WriteSiloPMPIOOverlandSum                False
+pfset Solver.WriteSiloPMPIOPressure                   False
+pfset Solver.WriteSiloPMPIOSaturation                 False
+pfset Solver.WriteSiloPMPIOSlopes                     False
+pfset Solver.WriteSiloPMPIOSpecificStorage            False
+pfset Solver.WriteSiloPMPIOSubsurfData                False
+pfset Solver.WriteSiloPMPIOTop                        False
+pfset Solver.WriteSiloPMPIOVelocities                 False
+pfset Solver.WriteSiloPressure                        False
+pfset Solver.WriteSiloSaturation                      False
+pfset Solver.WriteSiloSlopes                          False
+pfset Solver.WriteSiloSpecificStorage                 False
+pfset Solver.WriteSiloSubsurfData                     False
+pfset Solver.WriteSiloTop                             False
+pfset Solver.WriteSiloVelocities                      False
 
 #-----------------------------------------------------------------------------
 # Exact solution specification for error calculations

--- a/benchmarks/sinusoidal_medium/assets/validate_results.tcl
+++ b/benchmarks/sinusoidal_medium/assets/validate_results.tcl
@@ -10,46 +10,8 @@ set py_test_epsilon 9
 
 set passed 1
 
-
-# if ![pftestFile $runname.out.press.00000.pfb "Max difference in Pressure" $sig_digits] {
-#     set passed 0
-# }
-
-# set status [catch { exec python ../pfbdiff.py -q -e=1e-$py_test_epsilon $runname.out.press.00000.pfb ./correct_output/$runname.out.press.00000.pfb } result]
-# if { $status != 0 } {
-#   set passed 0
-#   puts $result
-# }
-
-# if ![pftestFile $runname.out.satur.00000.pfb "Max difference in Saturation" $sig_digits] {
-#     set passed 0
-# }
-
-# set status [catch { exec python ../pfbdiff.py -q -e=1e-$py_test_epsilon ./$runname.out.satur.00000.pfb ./correct_output/$runname.out.satur.00000.pfb } result]
-# if { $status != 0 } {
-#   set passed 0
-#   puts $result
-# }
-
-# foreach file "LW.out.eflx_lh_tot.00012.pfb
-#     LW.out.qflx_evap_soi.00012.pfb LW.out.swe_out.00012.pfb
-#     LW.out.eflx_lwrad_out.00012.pfb LW.out.qflx_evap_tot.00012.pfb
-#     LW.out.t_grnd.00012.pfb LW.out.eflx_sh_tot.00012.pfb
-#     LW.out.qflx_evap_veg.00012.pfb LW.out.t_soil.00012.pfb
-#     LW.out.eflx_soil_grnd.00012.pfb LW.out.qflx_infl.00012.pfb
-#     LW.out.qflx_evap_grnd.00012.pfb LW.out.qflx_tran_veg.00012.pfb" {
-
-#     if ![pftestFile $file "Max difference in $file" $sig_digits] { 
-#     set passed 0
-#     }
-    
-#     set status [catch { exec python ../pfbdiff.py -q -e=1e-$py_test_epsilon $file correct_output/$file  } result]
-#     if { $status != 0 } {
-#       set passed 0
-#       puts $result
-#     }
-    
-# }
+# TODO add validation.
+# PS: When adding validation, make sure to turn on outputs in the run script
 
 if $passed {
     puts "$runname : PASSED"

--- a/benchmarks/sinusoidal_tiny/assets/sinusoidal_no_size_args.tcl
+++ b/benchmarks/sinusoidal_tiny/assets/sinusoidal_no_size_args.tcl
@@ -326,24 +326,57 @@ pfset Geom.domain.ICPressure.RefPatch                   z-upper
 # Outputs
 # ------------------------------------------------------------
 #Writing output (all pfb):
+pfset Solver.PrintCLM                                 False
+pfset Solver.PrintConcentration                       False
+pfset Solver.PrintDZMultiplier                        False
+pfset Solver.PrintEvapTrans                           False
+pfset Solver.PrintEvapTransSum                        False
+pfset Solver.PrintLSMSink                             False
+pfset Solver.PrintMannings                            False
+pfset Solver.PrintMask                                False
+pfset Solver.PrintOverlandBCFlux                      False
+pfset Solver.PrintOverlandSum                         False
+pfset Solver.PrintPressure                            False
+pfset Solver.PrintSaturation                          False
+pfset Solver.PrintSlopes                              False
+pfset Solver.PrintSpecificStorage                     False
 pfset Solver.PrintSubsurfData                         False
-pfset Solver.PrintPressure                            True
-pfset Solver.PrintSaturation                          True
-pfset Solver.PrintMask                                True
+pfset Solver.PrintTop                                 False
+pfset Solver.PrintVelocities                          False
+pfset Solver.PrintWells                               False
 
 pfset Solver.WriteCLMBinary                           False
-pfset Solver.PrintCLM                                 True
-pfset Solver.WriteSiloSpecificStorage                 False
-pfset Solver.WriteSiloMannings                        False
-pfset Solver.WriteSiloMask                            False
-pfset Solver.WriteSiloSlopes                          False
-pfset Solver.WriteSiloSubsurfData                     False
-pfset Solver.WriteSiloPressure                        False
-pfset Solver.WriteSiloSaturation                      False
+pfset Solver.WriteSiloCLM                             False
+pfset Solver.WriteSiloConcentration                   False
+pfset Solver.WriteSiloDZMultiplier                    False
 pfset Solver.WriteSiloEvapTrans                       False
 pfset Solver.WriteSiloEvapTransSum                    False
+pfset Solver.WriteSiloMannings                        False
+pfset Solver.WriteSiloMask                            False
+pfset Solver.WriteSiloOverlandBCFlux                  False
 pfset Solver.WriteSiloOverlandSum                     False
-pfset Solver.WriteSiloCLM                             False
+pfset Solver.WriteSiloPMPIOConcentration              False
+pfset Solver.WriteSiloPMPIODZMultiplier               False
+pfset Solver.WriteSiloPMPIOEvapTrans                  False
+pfset Solver.WriteSiloPMPIOEvapTransSum               False
+pfset Solver.WriteSiloPMPIOMannings                   False
+pfset Solver.WriteSiloPMPIOMask                       False
+pfset Solver.WriteSiloPMPIOOverlandBCFlux             False
+pfset Solver.WriteSiloPMPIOOverlandSum                False
+pfset Solver.WriteSiloPMPIOPressure                   False
+pfset Solver.WriteSiloPMPIOSaturation                 False
+pfset Solver.WriteSiloPMPIOSlopes                     False
+pfset Solver.WriteSiloPMPIOSpecificStorage            False
+pfset Solver.WriteSiloPMPIOSubsurfData                False
+pfset Solver.WriteSiloPMPIOTop                        False
+pfset Solver.WriteSiloPMPIOVelocities                 False
+pfset Solver.WriteSiloPressure                        False
+pfset Solver.WriteSiloSaturation                      False
+pfset Solver.WriteSiloSlopes                          False
+pfset Solver.WriteSiloSpecificStorage                 False
+pfset Solver.WriteSiloSubsurfData                     False
+pfset Solver.WriteSiloTop                             False
+pfset Solver.WriteSiloVelocities                      False
 
 #-----------------------------------------------------------------------------
 # Exact solution specification for error calculations

--- a/benchmarks/sinusoidal_tiny/assets/validate_results.tcl
+++ b/benchmarks/sinusoidal_tiny/assets/validate_results.tcl
@@ -10,46 +10,8 @@ set py_test_epsilon 9
 
 set passed 1
 
-
-# if ![pftestFile $runname.out.press.00000.pfb "Max difference in Pressure" $sig_digits] {
-#     set passed 0
-# }
-
-# set status [catch { exec python ../pfbdiff.py -q -e=1e-$py_test_epsilon $runname.out.press.00000.pfb ./correct_output/$runname.out.press.00000.pfb } result]
-# if { $status != 0 } {
-#   set passed 0
-#   puts $result
-# }
-
-# if ![pftestFile $runname.out.satur.00000.pfb "Max difference in Saturation" $sig_digits] {
-#     set passed 0
-# }
-
-# set status [catch { exec python ../pfbdiff.py -q -e=1e-$py_test_epsilon ./$runname.out.satur.00000.pfb ./correct_output/$runname.out.satur.00000.pfb } result]
-# if { $status != 0 } {
-#   set passed 0
-#   puts $result
-# }
-
-# foreach file "LW.out.eflx_lh_tot.00012.pfb
-#     LW.out.qflx_evap_soi.00012.pfb LW.out.swe_out.00012.pfb
-#     LW.out.eflx_lwrad_out.00012.pfb LW.out.qflx_evap_tot.00012.pfb
-#     LW.out.t_grnd.00012.pfb LW.out.eflx_sh_tot.00012.pfb
-#     LW.out.qflx_evap_veg.00012.pfb LW.out.t_soil.00012.pfb
-#     LW.out.eflx_soil_grnd.00012.pfb LW.out.qflx_infl.00012.pfb
-#     LW.out.qflx_evap_grnd.00012.pfb LW.out.qflx_tran_veg.00012.pfb" {
-
-#     if ![pftestFile $file "Max difference in $file" $sig_digits] { 
-#     set passed 0
-#     }
-    
-#     set status [catch { exec python ../pfbdiff.py -q -e=1e-$py_test_epsilon $file correct_output/$file  } result]
-#     if { $status != 0 } {
-#       set passed 0
-#       puts $result
-#     }
-    
-# }
+# TODO add validation.
+# PS: When adding validation, make sure to turn on outputs in the run script
 
 if $passed {
     puts "$runname : PASSED"


### PR DESCRIPTION
Updates Sinusoidal tests so that they create no output files.
This really helps limit the amount of disk usage which can be an issue during concurrent tests.